### PR TITLE
Add support for building a Docker container

### DIFF
--- a/Dockerfile.multistage
+++ b/Dockerfile.multistage
@@ -1,0 +1,42 @@
+# Jitsi Colibri Exporter from https://github.com/symptog/jitsi-colibri-exporter
+# Multi-stage Docker example from https://www.callicoder.com/docker-golang-image-container-example/
+# Build by running "docker build -t jitsi-colibri-exporter -f Dockerfile.multistage ."
+
+# Start from the latest golang base image
+FROM golang:latest as builder
+
+# Add Maintainer Info
+LABEL maintainer="Jared Smith <jared@jaredsmith.net>"
+
+# Set the Current Working Directory inside the container
+WORKDIR /app
+
+# Copy go mod and sum files
+COPY go.mod go.sum ./
+
+# Download all dependencies. Dependencies will be cached if the go.mod and go.sum files are not changed
+RUN go mod download
+
+# Copy the source from the current directory to the Working Directory inside the container
+COPY . .
+
+# Build the Go app
+RUN CGO_ENABLED=0 GOOS=linux go build -a -installsuffix cgo -o main .
+
+
+######## Start a new stage from scratch #######
+FROM alpine:latest  
+
+RUN apk --no-cache add ca-certificates
+
+WORKDIR /root/
+
+# Copy the Pre-built binary file from the previous stage
+COPY --from=builder /app/main .
+
+# Expose port 9210 to the outside world
+EXPOSE 9210
+
+# Command to run the executable
+CMD ["./main"] 
+

--- a/README.md
+++ b/README.md
@@ -166,3 +166,14 @@ jitsi_colibri_videochannels 0
 # TYPE jitsi_colibri_videostreams gauge
 jitsi_colibri_videostreams 0
 ```
+
+# Docker container
+
+The Docker container is built via a multi-stage process.  The first process builds the
+binary (in a large container with lots of build dependencies), and then copies the binary
+to a much smaller container with just the necessary pieces to run.
+
+To build the Docker container, run:
+
+```docker build -t jitsi-colibri-exporter -f Dockerfile.multistage .```
+


### PR DESCRIPTION
This pull request adds support for building a Docker container, along with instructions on how to build it via a multi-stage build process.  Multi-stage is used so that the resulting container is as light-weight as possible.